### PR TITLE
enable partial upstream fix for secondary user SMS

### DIFF
--- a/src/java/com/android/internal/telephony/SMSDispatcher.java
+++ b/src/java/com/android/internal/telephony/SMSDispatcher.java
@@ -2819,10 +2819,6 @@ public abstract class SMSDispatcher extends Handler {
             SmsHeader smsHeader, boolean expectMore, String fullMessageText, boolean isText,
             boolean persistMessage, int priority, int validityPeriod, boolean isForVvm,
             long messageId, int messageRef, boolean skipShortCodeCheck) {
-        if (!Flags.smsMmsDeliverBroadcastsRedirectToMainUser()) {
-            callingUser = UserHandle.getUserHandleForUid(Binder.getCallingUid()).getIdentifier();
-        }
-
         // Get package info via packagemanager
         PackageManager pm = mContext.createContextAsUser(UserHandle.of(callingUser), 0)
                 .getPackageManager();


### PR DESCRIPTION
I've removed the downstream fix for this part of secondary user SMS issues [1] during 15 QPR1 port, but have missed that the flag that guards the upstream fix is not enabled in 15 QPR1.

[1] https://github.com/GrapheneOS/platform_frameworks_opt_telephony/commit/a7bd84afa7d2a53c7ba4dbdd6d1e658d7ec9b286#diff-adb2a56af3ec19299d5e54ba563d00802fb0623f737d80182fd82e09fd5c2752R2820