### PR TITLE
gmscompat: send client SMS OTP receival broadcasts to GmsCore

### DIFF
--- a/src/java/com/android/internal/telephony/InboundSmsHandler.java
+++ b/src/java/com/android/internal/telephony/InboundSmsHandler.java
@@ -1568,10 +1568,10 @@ public abstract class InboundSmsHandler extends StateMachine {
             }
             int result;
             if (containsOtp) {
-                String smsRetrieverHashMatchedPackageName = getSmsRetrieverTargetPackageName(
-                        textLinks);
+                List<String> smsRetrieverHashMatchedPackageNames = getSmsRetrieverTargetPackageNames(
+                        textLinks, user);
                 sendBroadcastToTrustedPackages(intent, permission, appOp, opts,
-                        resultReceiver, user, smsRetrieverHashMatchedPackageName);
+                        resultReceiver, user, smsRetrieverHashMatchedPackageNames);
                 result = SMS_OTP_EVALUATION__RESULT__EVALUATION_RESULT_HAS_OTP;
             } else {
                 sendBroadcastWithStandardPermissions(intent, permission, appOp, opts,
@@ -1625,12 +1625,16 @@ public abstract class InboundSmsHandler extends StateMachine {
     // was matched to a specific app. This method extracts and returns the package name for that
     // intended app from the TextClassifier response.
     @Nullable
-    private String getSmsRetrieverTargetPackageName(Collection<TextLinks.TextLink> links) {
+    private List<String> getSmsRetrieverTargetPackageNames(Collection<TextLinks.TextLink> links, UserHandle user) {
         for (TextLinks.TextLink link : links) {
             for (int i = 0; i < link.getEntityCount(); i++) {
                 if (link.getEntity(i).equals(TextClassifier.TYPE_SMS_RETRIEVER_OTP)) {
-                    return link.getExtras().getString(
+                    String pkgName = link.getExtras().getString(
                             TextClassifier.EXTRA_SMS_RETRIEVER_HASH_MATCHED_PACKAGE);
+                    if (pkgName == null) {
+                        return null;
+                    }
+                    return InboundSmsHandlerExt.processSmsRetrieverMatchedPackage(mContext, user, pkgName);
                 }
             }
         }
@@ -1651,10 +1655,11 @@ public abstract class InboundSmsHandler extends StateMachine {
     @SuppressLint("MissingPermission")
     private void sendBroadcastToTrustedPackages(Intent intent, String permission,
             String appOp, Bundle opts, SmsBroadcastReceiver resultReceiver, UserHandle user,
-            @Nullable String additionalTrustedPackage) {
+            @Nullable List<String> additionalTrustedPackages) {
         Set<String> trustedPackages = SmsManager.getSmsOtpTrustedPackages(mContext, user);
-        if (additionalTrustedPackage != null) {
-            trustedPackages.add(additionalTrustedPackage);
+        if (additionalTrustedPackages != null) {
+            logd("sendBroadcastToTrustedPackages: additionalTrustedPackages: " + Arrays.toString(additionalTrustedPackages.toArray()));
+            trustedPackages.addAll(additionalTrustedPackages);
         }
         final String[] trustedPackagesArray = new String[trustedPackages.size()];
         int i = 0;

--- a/src/java/com/android/internal/telephony/InboundSmsHandlerExt.java
+++ b/src/java/com/android/internal/telephony/InboundSmsHandlerExt.java
@@ -1,0 +1,42 @@
+package com.android.internal.telephony;
+
+import android.annotation.Nullable;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.ext.AppInfoExtFlag;
+import android.ext.PackageId;
+import android.os.UserHandle;
+
+import java.util.List;
+
+class InboundSmsHandlerExt {
+
+    @Nullable
+    static List<String> processSmsRetrieverMatchedPackage(Context ctx, UserHandle user, String pkgName) {
+        PackageManager pm = ctx.getPackageManager();
+        ApplicationInfo appInfo;
+        try {
+            appInfo = pm.getApplicationInfoAsUser(pkgName, 0, user);
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
+
+        if (appInfo.ext().hasFlag(AppInfoExtFlag.HAS_GMSCORE_CLIENT_LIBRARY)) {
+            try {
+                if (pm.getApplicationInfoAsUser(PackageId.GMS_CORE_NAME, 0, user)
+                        .ext().getPackageId() == PackageId.GMS_CORE) {
+
+                    if (pm.checkPermission(android.Manifest.permission.RECEIVE_SMS,
+                            PackageId.GMS_CORE_NAME) == PackageManager.PERMISSION_GRANTED) {
+                        // GmsCompat: allow GmsCore to read SMS OTP of its clients if GmsCore has
+                        // the SMS permission
+                        return List.of(pkgName, PackageId.GMS_CORE_NAME);
+                    }
+                }
+            } catch (PackageManager.NameNotFoundException ignored) {}
+        }
+
+        return List.of(pkgName);
+    }
+}


### PR DESCRIPTION
Since 16 QPR2, unprivileged apps that have the SMS permission aren't allowed to read OTP SMS that aren't addressed to them.

This commit allows GmsCore to receive OTP SMS receival broadcasts of SMS that are addressed to its clients. GmsCore is trusted by its clients and they run the GmsCore client library inside their own processes.

Depends on https://github.com/GrapheneOS/platform_packages_providers_TelephonyProvider/pull/7

Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/4823
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/7073