### PR TITLE
publish satellite disabled when satellite service is unsupported

### DIFF
--- a/src/java/com/android/internal/telephony/satellite/SatelliteController.java
+++ b/src/java/com/android/internal/telephony/satellite/SatelliteController.java
@@ -1104,6 +1104,9 @@ public class SatelliteController extends Handler {
 
         mAlarmManager = mContext.getSystemService(AlarmManager.class);
         scheduleRegularMetricReportTimer();
+        if (!mSatelliteModemInterface.isSatelliteServiceSupported()) {
+            notifyInitialSatelliteDisabledState("SatelliteController constructor");
+        }
         logd("Satellite Tracker is created");
     }
 
@@ -1791,7 +1794,7 @@ public class SatelliteController extends Handler {
                         updateSatelliteEnabledState(enabled, "EVENT_IS_SATELLITE_ENABLED_DONE");
                     }
                 } else if (error == SatelliteManager.SATELLITE_RESULT_REQUEST_NOT_SUPPORTED) {
-                    updateSatelliteSupportedState(false);
+                    updateSatelliteUnsupportedState("EVENT_IS_SATELLITE_ENABLED_DONE");
                 }
                 ((ResultReceiver) request.argument).send(error, bundle);
                 decrementResultReceiverCount("SC:requestIsSatelliteEnabled");
@@ -1818,7 +1821,11 @@ public class SatelliteController extends Handler {
                         boolean supported = (boolean) ar.result;
                         plogd("isSatelliteSupported: " + supported);
                         bundle.putBoolean(SatelliteManager.KEY_SATELLITE_SUPPORTED, supported);
-                        updateSatelliteSupportedState(supported);
+                        if (supported) {
+                            updateSatelliteSupportedState(true);
+                        } else {
+                            updateSatelliteUnsupportedState("EVENT_IS_SATELLITE_SUPPORTED_DONE");
+                        }
                     }
                 }
                 ((ResultReceiver) request.argument).send(error, bundle);
@@ -5373,6 +5380,21 @@ public class SatelliteController extends Handler {
         notifySatelliteSupportedStateChanged(supported);
     }
 
+    private void updateSatelliteUnsupportedState(String caller) {
+        updateSatelliteSupportedState(false);
+        notifyInitialSatelliteDisabledState(caller);
+    }
+
+    private void notifyInitialSatelliteDisabledState(String caller) {
+        if (getIsSatelliteEnabled() != null) {
+            return;
+        }
+        // Seed listener replay without caching an enabled state; later requests can still query
+        // the satellite service if it becomes available.
+        notifyEnabledStateChanged(false);
+        plogd(caller + ": notified initial satellite disabled state");
+    }
+
     private void updateSatelliteEnabledState(boolean enabled, String caller) {
         setIsSatelliteEnabled(enabled);
         if (mSatelliteSessionController != null) {
@@ -5646,7 +5668,11 @@ public class SatelliteController extends Handler {
             return;
         }
 
-        updateSatelliteSupportedState(supported);
+        if (supported) {
+            updateSatelliteSupportedState(true);
+        } else {
+            updateSatelliteUnsupportedState("EVENT_SATELLITE_SUPPORTED_STATE_CHANGED");
+        }
 
         Boolean isSatelliteEnabled = getIsSatelliteEnabled();
          /* In case satellite has been reported as not support from modem, but satellite is

--- a/tests/telephonytests/src/com/android/internal/telephony/satellite/SatelliteControllerTest.java
+++ b/tests/telephonytests/src/com/android/internal/telephony/satellite/SatelliteControllerTest.java
@@ -803,6 +803,41 @@ public class SatelliteControllerTest extends TelephonyTest {
     }
 
     @Test
+    public void testNoSatelliteServiceSupported_notifiesInitialDisabledState() {
+        reset(mTelephonyRegistryManager);
+        reset(mMockSatelliteModemInterface);
+        reset(mMockSatelliteSessionController);
+        doReturn(false).when(mMockSatelliteModemInterface).isSatelliteServiceSupported();
+
+        new TestSatelliteController(mContext, Looper.myLooper(), mFeatureFlags);
+        processAllMessages();
+
+        verify(mTelephonyRegistryManager).notifySatelliteStateChanged(eq(false));
+        verify(mMockSatelliteSessionController, never())
+                .onSatelliteEnabledStateChanged(anyBoolean());
+        verify(mMockSatelliteModemInterface, never()).requestSatelliteEnabled(
+                any(SatelliteModemEnableRequestAttributes.class), any(Message.class));
+        verify(mMockSatelliteModemInterface, never()).requestIsSatelliteEnabled(
+                any(Message.class));
+    }
+
+    @Test
+    public void testSatelliteNotSupported_notifiesInitialDisabledState() {
+        reset(mTelephonyRegistryManager);
+        reset(mMockSatelliteSessionController);
+        clearInvocations(mMockSatelliteModemInterface);
+        setUpResponseForRequestIsSatelliteSupported(false, SATELLITE_RESULT_SUCCESS);
+
+        verifySatelliteSupported(false, SATELLITE_RESULT_SUCCESS);
+
+        verify(mTelephonyRegistryManager).notifySatelliteStateChanged(eq(false));
+        verify(mMockSatelliteSessionController, never())
+                .onSatelliteEnabledStateChanged(anyBoolean());
+        verify(mMockSatelliteModemInterface, never()).requestSatelliteEnabled(
+                any(SatelliteModemEnableRequestAttributes.class), any(Message.class));
+    }
+
+    @Test
     public void testShouldTurnOffCarrierSatelliteForEmergencyCall() throws Exception {
         DatagramControllerTest.TestDatagramController datagramController = mock(
                 DatagramControllerTest.TestDatagramController.class);


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7747

When the satellite service is unsupported, an initial satellite enabled state is never published. This can happen when the device still declares android.hardware.telephony.satellite (semantically, this seems like a declaration that the hardware does support satellite), but the satellite service package is not configured or included. Theoretically, even if satellite packages were included, any errors to bind to service or service failing to call back could also result in this issue.

Satellite state listeners only receive an initial value on registration if TelephonyRegistry has already been notified of a satellite enabled state at least once [^1]. Apps may rely on the listener callback firing before continuing in their code. Android Auto 16.6.661444 does this for its cellular signal indicator when the satellite feature is present (and Build.VERSION.SDK_INT >= 36; in the previous Android Auto version, this was Build.VERSION.SDK_INT > 36 so the path never activated). Since satellite mode never gets emitted from the satellite state change listener, Android Auto's network info update never runs, so the drawables for cell signal icon stay unassigned

Publish an initial disabled state when the satellite service is unsupported so that satellite change listeners will always see that the state is disabled when satellite unsupported. Note that we avoid caching modem enabled state or issuing a modem enable/disable request.

Test: atest FrameworksTelephonyTests:com.android.internal.telephony.satellite.SatelliteControllerTest which has an unrelated test failure for `testSatellitePerPlmnConfigurationUpdate_ForCarrierWithBothAutoAndManualSatellite`
      
Test: Android Auto 16.6.661444 cellular icon is now shown on caiman (declares satellite support)

[^1]: https://github.com/GrapheneOS/platform_frameworks_base/blob/2026050700/services/core/java/com/android/server/TelephonyRegistry.java#L3542